### PR TITLE
Fixing incorrect names for `opt` in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ This should seem (mostly) very familiar to you if you've used any other Javascri
     var platoon = require('platoon');
 
     exports.ExampleTest = platoon.unit({
-        setUp:function(callback) {
+        setup:function(callback) {
             callback();
         },
-        tearDown:function(callback) {
+        teardown:function(callback) {
             callback();
         },
     },


### PR DESCRIPTION
I was trying to work out why my `setUp` and `tearDown` options weren't being called; I had a look at the code, and noticed that you're actually pulling out `setup` and `teardown`! Fixed my test cases, so I thought I'd send a PR to update the README :)
